### PR TITLE
fix: validate author email and make author fields optional

### DIFF
--- a/src/prothon/cli.py
+++ b/src/prothon/cli.py
@@ -123,8 +123,11 @@ def main(
         default=project_name.lower().replace("-", "_").replace(" ", "_"),
     )
     description = typer.prompt("Description", default="A Python project")
-    author_name = typer.prompt("Author name")
-    author_email = typer.prompt("Author email")
+    author_name = typer.prompt("Author name", default="")
+    author_email = typer.prompt("Author email", default="")
+    while author_email and "@" not in author_email:
+        typer.echo("Must be a valid email address (e.g. user@example.com)")
+        author_email = typer.prompt("Author email", default="")
 
     python_version = typer.prompt(
         "Python version (3.11/3.12/3.13)", default="3.13"

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -6,9 +6,15 @@ requires-python = ">={{ python_version }}"
 {% if license != 'None' %}
 license = "{{ license }}"
 {% endif %}
+{% if author_name and author_email %}
 authors = [
     { name = "{{ author_name }}", email = "{{ author_email }}" },
 ]
+{% elif author_name %}
+authors = [
+    { name = "{{ author_name }}" },
+]
+{% endif %}
 readme = "README.md"
 
 [build-system]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -116,6 +116,39 @@ def test_git_initialized(generated_project):
     assert (generated_project / ".git").is_dir()
 
 
+def test_authors_omitted_when_both_empty(tmp_path):
+    context = {
+        "project_name": "no-author",
+        "module_name": "no_author",
+        "description": "No author project",
+        "author_name": "",
+        "author_email": "",
+        "python_version": "3.13",
+        "license": "MIT",
+    }
+    dest = tmp_path / "no-author"
+    generate(dest, context)
+    content = (dest / "pyproject.toml").read_text()
+    assert "authors" not in content
+
+
+def test_authors_name_only(tmp_path):
+    context = {
+        "project_name": "name-only",
+        "module_name": "name_only",
+        "description": "Name only project",
+        "author_name": "Test Author",
+        "author_email": "",
+        "python_version": "3.13",
+        "license": "MIT",
+    }
+    dest = tmp_path / "name-only"
+    generate(dest, context)
+    content = (dest / "pyproject.toml").read_text()
+    assert 'name = "Test Author"' in content
+    assert "email" not in content
+
+
 def test_license_none_excluded(tmp_path):
     context = {
         "project_name": "no-license",


### PR DESCRIPTION
## Summary
- Make author name and email optional (default to empty string) so users can skip them
- Validate email contains `@` if provided, re-prompting on invalid input
- Conditionally render `authors` field in pyproject.toml template: both fields, name-only, or omitted entirely

## Test plan
- [x] Existing tests pass (16/16)
- [x] New test: `test_authors_omitted_when_both_empty` — verifies no authors field when both empty
- [x] New test: `test_authors_name_only` — verifies name-only rendering without email
- [ ] Manual: run `uvx --from git+... prothon` with empty author fields, verify generated project builds
- [ ] Manual: enter invalid email (no @), verify re-prompt occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated pyproject.toml now includes an authors section with name and email metadata when author information is provided during project initialization.

* **Bug Fixes**
  * CLI now validates email format, requiring the "@" symbol when an email address is provided; invalid entries trigger a clear error message.

* **Tests**
  * Added comprehensive tests for author metadata generation and omission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->