### PR TITLE
feat: implement init_existing Path A for pyproject-absent projects

### DIFF
--- a/src/prothon/scaffold.py
+++ b/src/prothon/scaffold.py
@@ -221,7 +221,7 @@ def _collect_project_details() -> dict[str, str]:
     }
 
 
-def _run_copier_init(dest: Path, data: dict) -> None:
+def _run_copier_init(dest: Path, data: dict[str, str]) -> None:
     """Run Copier for project adoption (no git init, no commits).
 
     Args:
@@ -237,7 +237,7 @@ def _run_copier_init(dest: Path, data: dict) -> None:
         defaults=True,
         unsafe=True,
         skip_tasks=True,
-        skip_if_exists=["*"],
+        skip_if_exists=["**"],
         exclude=["docs/*", "AGENTS.md*"],
         vcs_ref="HEAD",
     )

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -414,7 +414,7 @@ def test_init_existing_path_a_calls_copier(tmp_path):
     assert kw["defaults"] is True
     assert kw["unsafe"] is True
     assert kw["skip_tasks"] is True
-    assert kw["skip_if_exists"] == ["*"]
+    assert kw["skip_if_exists"] == ["**"]
     assert kw["exclude"] == ["docs/*", "AGENTS.md*"]
     assert kw["vcs_ref"] == "HEAD"
 


### PR DESCRIPTION
### **User description**
## Summary

- Implements Path A for `prothon init`: when `pyproject.toml` is absent, prompts for project details and scaffolds full Python structure via Copier
- Adds two-path init tests verifying both Path A (pyproject absent) and Path B (pyproject present)
- Compliance verification: 97% PASS (70/72 items)

## Changes

### `src/prothon/scaffold.py`
- Added `_collect_project_details()` using `typer.prompt()` for 6 inputs (module_name, description, author_name, author_email, python_version, license)
- Added `_run_copier_init()` with `skip_tasks=True`, `skip_if_exists=["*"]`, `exclude=["docs/*", "AGENTS.md*"]`
- Updated `init_existing()` to branch on `pyproject.toml` presence

### `tests/test_scaffold.py`
- Added `test_init_existing_path_a_calls_copier` — verifies Copier is invoked with correct params when no pyproject.toml
- Added `test_init_existing_path_a_creates_common_overlay` — verifies common overlay created in Path A
- Added `test_init_existing_path_b_skips_copier` — verifies Copier skipped when pyproject.toml exists
- Updated existing Path B tests to create `pyproject.toml` fixture

## Requirements Satisfied

- R17a: When `pyproject.toml` absent, prompt for project details and scaffold full Python structure via Copier (no git init/commit)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements Path A for init_existing: scaffolds Python structure via Copier when pyproject.toml absent

- Adds _collect_project_details() to interactively prompt for 6 project inputs

- Adds _run_copier_init() to invoke Copier with appropriate configuration

- Adds comprehensive tests for both Path A (no pyproject.toml) and Path B (pyproject.toml exists)

- Updates existing tests to create pyproject.toml fixture for Path B verification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["init_existing called"] --> B{"pyproject.toml exists?"}
  B -->|No| C["Path A: Collect details"]
  C --> D["Run Copier scaffold"]
  D --> E["Create common overlay"]
  B -->|Yes| F["Path B: Skip Copier"]
  F --> E
  E --> G["Return created paths"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scaffold.py</strong><dd><code>Add Path A scaffolding with Copier integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/prothon/scaffold.py

<ul><li>Added _collect_project_details() function using typer.prompt() for 6 <br>interactive inputs<br> <li> Added _run_copier_init() function to invoke Copier with <br>skip_tasks=True and appropriate exclusions<br> <li> Updated init_existing() to branch on pyproject.toml presence and call <br>Copier for Path A<br> <li> Fixed documentation reference from <code>uvx prothon compliance</code> to <code>prothon </code><br><code>compliance</code></ul>


</details>


  </td>
  <td><a href="https://github.com/jackedney/prothon/pull/7/files#diff-07057d38aa291f7dd7c45642762fb7c196ba3eb2b3ccd7a9e0cc026cfcecc777">+47/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scaffold.py</strong><dd><code>Add Path A/B tests and update existing fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_scaffold.py

<ul><li>Added test_init_existing_path_a_calls_copier() to verify Copier <br>invocation with correct parameters<br> <li> Added test_init_existing_path_a_creates_common_overlay() to verify <br>overlay creation in Path A<br> <li> Added test_init_existing_path_b_skips_copier() to verify Copier is <br>skipped when pyproject.toml exists<br> <li> Updated 11 existing tests to create pyproject.toml fixture for Path B <br>verification<br> <li> Updated test docstrings to clarify Path B behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/jackedney/prothon/pull/7/files#diff-90fc7a3f07beaf760095aaf49f2bccfccf87a7dd0bea020509fb46ceca71d4db">+97/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive prompts collect project details during initialization.
  * Automatic template adoption runs when no project config file is present; skipped when a config file exists.

* **Bug Fixes / Behavior**
  * Initialization consistently creates docs, agent guidance, symlinks, and skills artifacts in both flows.
  * Updated user-facing guidance for the compliance command.

* **Tests**
  * Expanded coverage for both config-present and config-absent initialization paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->