### PR TITLE
fix: launch opencode in interactive TUI mode instead of headless run

### DIFF
--- a/src/prothon/assistant.py
+++ b/src/prothon/assistant.py
@@ -77,7 +77,7 @@ class OpenCodeBackend:
 
     def build_command(self, skill_name: str, cwd: Path) -> list[str]:
         """Return subprocess argv for an opencode session with *skill_name*."""
-        return [self.cli_command, "run", "--command", skill_name]
+        return [self.cli_command, "--prompt", f"/{skill_name}"]
 
     def sync_skills(self) -> None:
         """Symlink bundled skills into opencode's discovery directory."""

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -144,27 +144,17 @@ def test_opencode_backend_properties() -> None:
 
 
 def test_opencode_backend_build_command() -> None:
-    """build_command constructs the expected argv."""
+    """build_command constructs the expected argv for interactive TUI mode."""
     backend = OpenCodeBackend()
     result = backend.build_command("prothon-spec-writer", Path("/tmp"))
-    assert result == ["opencode", "run", "--command", "prothon-spec-writer"]
+    assert result == ["opencode", "--prompt", "/prothon-spec-writer"]
 
 
-def test_opencode_backend_build_command_no_bare_slash_args() -> None:
-    """build_command must not produce args that opencode would treat as a project path.
-
-    opencode's positional argument is a directory to chdir into, so any
-    argv element starting with '/' (other than the binary itself) would be
-    misinterpreted as a filesystem path instead of a skill invocation.
-    """
+def test_opencode_backend_build_command_uses_slash_prefix() -> None:
+    """build_command prefixes skill name with '/' so opencode treats it as a command."""
     backend = OpenCodeBackend()
     cmd = backend.build_command("prothon-patterns-writer", Path("/tmp"))
-    non_binary_args = cmd[1:]  # skip the binary name
-    slash_args = [a for a in non_binary_args if a.startswith("/")]
-    assert slash_args == [], (
-        f"opencode build_command produced path-like args {slash_args} "
-        "that would be misinterpreted as a project directory"
-    )
+    assert cmd[-1] == "/prothon-patterns-writer"
 
 
 def test_opencode_backend_env_overrides() -> None:


### PR DESCRIPTION
## Summary

- `opencode run --command` runs in non-interactive headless mode, causing skills to exit immediately without opening the TUI
- Changed `OpenCodeBackend.build_command()` to use `opencode --prompt /skill-name`, which opens the interactive TUI and invokes the skill as a slash command
- Updated tests to reflect the new command format

## Test plan

- [x] All 256 tests pass
- [x] All quality checks pass (`poe check`)
- [ ] Manual: run `prothon patterns --agent opencode` and verify the TUI opens with the skill loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated backend skill invocation mechanism to use an improved command format for better consistency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->