### PR TITLE
feat: add model/provider config for opencode assistant

### DIFF
--- a/.agents/skills/domain-ai-agent-orchestration/SKILL.md
+++ b/.agents/skills/domain-ai-agent-orchestration/SKILL.md
@@ -26,7 +26,7 @@ user-invocable: false
 - **Reference** (tech-*, style-*, optim-*, domain-*) -- passive context loaded by agents when relevant, not directly invoked
 
 **Skill discovery:** Agents auto-discover skills in two locations:
-1. **Bundled skills** -- synced from `src/prothon/skills/` to `~/.claude/skills/` (global)
+1. **Bundled skills** -- synced from `src/prothon/skills/` to the backend's discovery directory (global)
 2. **Project skills** -- in `.agents/skills/` (project-local, includes generated reference skills)
 
 Bundled skills use `prothon-` prefix. Project skills use category prefixes (`tech-`, `style-`, `optim-`, `domain-`).
@@ -37,9 +37,16 @@ Bundled skills use `prothon-` prefix. Project skills use category prefixes (`tec
 - `name` -- human-readable name for error messages (e.g. "Claude Code", "opencode")
 - `cli_command` -- binary name to look up on PATH (e.g. "claude", "opencode")
 - `install_hint` -- installation URL or command for actionable error messages when binary is missing
-- `build_command(skill_name, cwd)` -- constructs subprocess argv for launching a session
+- `build_command(skill_name, cwd, model=None)` -- constructs subprocess argv for launching a session. The optional `model` parameter is the resolved `provider/model` string for opencode.
 - `sync_skills()` -- installs/symlinks bundled skills to the assistant's discovery location
 - `env_overrides()` -- returns dict of extra environment variables for non-interactive execution
+
+**Agent configuration precedence (5-level chain, per DESIGN.md):**
+1. CLI flag (`--agent` / `-a` per-command)
+2. Environment variable (`PROTHON_AGENT`)
+3. Project config (`[tool.prothon]` in `pyproject.toml`)
+4. Global config (`~/.config/prothon/config.toml`)
+5. Default: `claude-code`
 
 ## Mental Models
 
@@ -51,8 +58,6 @@ Bundled skills use `prothon-` prefix. Project skills use category prefixes (`tec
 
 **Skill sync is installation, not runtime.** Skills are symlinked before launching. They do not change during a session. Per DESIGN.md, each backend maintains its own set of direct symlinks -- no shared central location.
 
-**Assistant selection is a 5-level precedence chain.** CLI flag > env var > pyproject.toml > global config > default ("claude-code"). The first non-empty value wins. This matches the convention used by uv, ruff, and pip.
-
 **Context scoping is a quality lever.** The promise contract's `context_files` and `reference_skills` fields limit what each task's agent sees. Narrow context aids focus; broad context aids cross-cutting understanding.
 
 ## Edge Cases & Gotchas
@@ -62,9 +67,10 @@ Bundled skills use `prothon-` prefix. Project skills use category prefixes (`tec
 - **Skill symlinks can go stale.** Package upgrades may leave broken symlinks. `sync_skills()` must handle broken symlinks by removing and recreating them.
 - **Agent instruction loading order.** Claude Code loads `CLAUDE.md` from the project root, then from `~/.claude/`. Project-level instructions override user-level.
 - **Large context degrades quality.** Loading too many files or skills into a single session reduces focus. The promise contract's context fields exist to scope each task.
-- **Binary not found is common.** Users may not have Claude Code installed. The backend must check for the binary before launching and provide a clear installation message.
+- **Binary not found is common.** Users may not have Claude Code installed. The backend must check for the binary before launching and provide a clear installation message via `install_hint`.
 - **Keyboard interrupt during session.** Let the subprocess handle its own cleanup. Do not send SIGKILL immediately.
 - **Template vs runtime skill generation.** Bundled skills are static. Reference skills are generated per-project. Generation must not overwrite bundled skills.
+- **Model configuration for opencode.** When resolved agent is `opencode`, the `--model` and `--provider` flags control which model is used, joined as `provider/model`. If model contains `/`, provider is ignored. Both or neither must be set.
 
 ## Validation Rules
 

--- a/.agents/skills/domain-template-engines/SKILL.md
+++ b/.agents/skills/domain-template-engines/SKILL.md
@@ -57,4 +57,4 @@ The key differentiator is `run_update`: it compares the old template output, new
 - Template rendering must produce valid files -- syntactically correct TOML, YAML, Python, etc.
 - All template conditionals (`when`, `{% if %}`) must have test coverage for both branches.
 - The template must produce six items from user input: module name, description, author name, email, Python version, license (per SPEC R2).
-- Template assets live in `src/prothon/template/` and are included via `[tool.hatch.build.targets.wheel.force-include]` (per DESIGN.md).
+- Template assets live at `template/` in the project root and are included via `[tool.hatch.build.targets.wheel.force-include]` (per DESIGN.md).

--- a/.agents/skills/optim-subprocess-management/SKILL.md
+++ b/.agents/skills/optim-subprocess-management/SKILL.md
@@ -72,12 +72,13 @@ subprocess.Popen(["claude", "--skill", skill_name])
 # 1. Check binary existence (shutil.which)
 # 2. Sync skills (backend.sync_skills())
 # 3. Merge environment (os.environ + backend.env_overrides())
-# 4. Execute subprocess
-# 5. Check return code
+# 4. Build command (backend.build_command(skill, cwd, model=resolved_model))
+# 5. Execute subprocess
+# 6. Check return code
 
 try:
     env = {**os.environ, **backend.env_overrides()}
-    command = backend.build_command(skill_name, cwd=project_root)
+    command = backend.build_command(skill_name, cwd=project_root, model=resolved_model)
     result = subprocess.run(
         command,
         cwd=project_root,

--- a/.agents/skills/style-python/SKILL.md
+++ b/.agents/skills/style-python/SKILL.md
@@ -122,12 +122,18 @@ def check_task(
 
 ## Formatting Rules
 
-**Auto-enforced by ruff format:**
+**Auto-enforced by ruff format (configured in `pyproject.toml`):**
 - Line length: 88 characters (Black default)
 - Indentation: 4 spaces (no tabs)
 - String quotes: double quotes (`"string"`)
 - Trailing commas: preserved (magic trailing comma respected)
 - Parenthesized line continuations over backslash
+
+**Ruff lint rules in this project:**
+- `ruff check src/ tests/` runs linting
+- `ruff format --check src/ tests/` checks formatting
+- All checks run via `poe check` and pre-commit hooks
+- Bandit security checks skip `B404` (subprocess import), `B603` (subprocess call), `B607` (partial executable path), `B701` (Jinja2 autoescape) -- these are intentional patterns in this codebase
 
 **Manual conventions:**
 - Group related classes in one module (e.g., `Task`, `Metadata`, `Promise` in `promise.py`)

--- a/.agents/skills/tech-pytest/SKILL.md
+++ b/.agents/skills/tech-pytest/SKILL.md
@@ -106,8 +106,8 @@ def test_missing_binary(monkeypatch):
         check_binary("claude")
 
 def test_env_variable(monkeypatch):
-    monkeypatch.setenv("PROTHON_ASSISTANT", "opencode")
-    assert resolve_assistant() == "opencode"
+    monkeypatch.setenv("PROTHON_AGENT", "opencode")
+    assert resolve_agent() == "opencode"
 
 def test_chdir(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)

--- a/.agents/skills/tech-rich/SKILL.md
+++ b/.agents/skills/tech-rich/SKILL.md
@@ -49,6 +49,8 @@ console.print(table)
 ### Column styling and alignment
 
 ```python
+from rich.table import Column, Table
+
 table = Table(title="Star Wars Movies")
 table.add_column("Released", justify="right", style="cyan", no_wrap=True)
 table.add_column("Title", style="magenta")
@@ -124,21 +126,6 @@ from rich.progress import track
 
 for item in track(range(100), description="Processing..."):
     process(item)
-```
-
-For custom progress bars with multiple columns:
-
-```python
-from rich.table import Column
-from rich.progress import Progress, BarColumn, TextColumn
-
-text_column = TextColumn("{task.description}", table_column=Column(ratio=1))
-bar_column = BarColumn(bar_width=None, table_column=Column(ratio=2))
-
-with Progress(text_column, bar_column, expand=True) as progress:
-    task = progress.add_task("Working...", total=100)
-    for n in range(100):
-        progress.update(task, advance=1)
 ```
 
 ## Gotchas & Pitfalls

--- a/.agents/skills/tech-tomlkit/SKILL.md
+++ b/.agents/skills/tech-tomlkit/SKILL.md
@@ -112,17 +112,25 @@ tomlkit.comment("This is a comment")
 tomlkit.nl()                                  # newline
 ```
 
-### Serialization with sort_keys
+### Reading TOML config files for agent/model resolution
 
 ```python
-# From a plain Python dict (no formatting metadata)
-config = {"server": {"host": "0.0.0.0", "port": 3000}}
-output = tomlkit.dumps(config, sort_keys=True)
+import tomlkit
+from pathlib import Path
 
-# From a TOMLDocument (preserves original ordering)
-doc = tomlkit.parse(content)
-output = tomlkit.dumps(doc)  # do NOT use sort_keys on human-authored files
+def read_project_config(pyproject: Path) -> dict:
+    """Read [tool.prothon] from pyproject.toml."""
+    doc = tomlkit.parse(pyproject.read_text())
+    return dict(doc.get("tool", {}).get("prothon", {}))
+
+def read_global_config(config_path: Path) -> dict:
+    """Read ~/.config/prothon/config.toml."""
+    if not config_path.exists():
+        return {}
+    return dict(tomlkit.parse(config_path.read_text()))
 ```
+
+Per DESIGN.md, both `pyproject.toml` (`[tool.prothon]`) and `~/.config/prothon/config.toml` store agent, model, and provider settings. tomlkit reads both.
 
 ## Gotchas & Pitfalls
 
@@ -136,7 +144,7 @@ output = tomlkit.dumps(doc)  # do NOT use sort_keys on human-authored files
 
 ## Idiomatic Usage
 
-**Do:** Use `tomlkit.parse()` + `tomlkit.dumps()` for roundtrip editing of human-authored files.
+**Do:** Use `tomlkit.parse()` + `tomlkit.dumps()` for roundtrip editing of human-authored files (like `change_promise.toml`).
 
 **Don't:** Use `tomlkit` for read-only access -- use stdlib `tomllib` instead (faster, no dependency).
 
@@ -147,13 +155,5 @@ output = tomlkit.dumps(doc)  # do NOT use sort_keys on human-authored files
 **Do:** Use `TOMLFile` when the read-modify-write cycle targets a single file path.
 
 **Do:** Use `item().comment("...")` to attach inline comments when scaffolding TOML from scratch.
-```python
-import tomlkit
-
-doc = tomlkit.document()
-doc["server"] = tomlkit.table()
-doc["server"]["ssl"] = True
-doc["server"].item("ssl").comment("Enable SSL")
-```
 
 **Don't:** Use `sort_keys=True` on `dumps()` for human-authored files -- it destroys intentional ordering. Reserve sorting for machine-generated output only.

--- a/.agents/skills/tech-typer/SKILL.md
+++ b/.agents/skills/tech-typer/SKILL.md
@@ -78,6 +78,40 @@ def check(
     ...
 ```
 
+### Per-command options with envvar fallback
+
+Per DESIGN.md, `--agent` is a per-command option (not a global callback), defined on each session command via a shared `AgentOption` annotated type. `--model` and `--provider` follow the same pattern.
+
+```python
+from typing import Annotated
+
+AgentOption = Annotated[
+    str | None,
+    typer.Option("--agent", "-a", envvar="PROTHON_AGENT", help="AI assistant backend"),
+]
+
+ModelOption = Annotated[
+    str | None,
+    typer.Option("--model", "-m", envvar="PROTHON_MODEL", help="Model name"),
+]
+
+ProviderOption = Annotated[
+    str | None,
+    typer.Option("--provider", "-p", envvar="PROTHON_PROVIDER", help="Model provider"),
+]
+
+@app.command()
+def spec(
+    agent: AgentOption = None,
+    model: ModelOption = None,
+    provider: ProviderOption = None,
+):
+    resolved = resolve_agent(agent)
+    ...
+```
+
+Typer natively handles env var fallback via `envvar=`. Each session command (`spec`, `design`, `patterns`, `execute`, `compliance`) declares these options. Non-session commands (`new`, `init`, `promise *`) do not.
+
 ### Prompting for interactive input
 
 ```python
@@ -88,28 +122,6 @@ def new():
     confirm = typer.confirm("Proceed?")
 ```
 
-### Callbacks for app-level (global) options
-
-```python
-state = {"verbose": False, "assistant": None}
-
-@app.callback()
-def main(
-    assistant: Annotated[
-        str | None,
-        typer.Option("--assistant", "-a", envvar="PROTHON_ASSISTANT", help="AI assistant backend"),
-    ] = None,
-    verbose: Annotated[bool, typer.Option("--verbose")] = False,
-):
-    """Prothon CLI -- documentation-driven development."""
-    if assistant:
-        state["assistant"] = assistant
-    if verbose:
-        state["verbose"] = True
-```
-
-Global options on `@app.callback()` apply to all subcommands. Typer natively handles env var fallback via `envvar=`.
-
 ### Rich markup mode for help text
 
 ```python
@@ -118,10 +130,6 @@ app = typer.Typer(rich_markup_mode="rich")
 @app.command()
 def create(
     username: Annotated[str, typer.Argument(help="The username to create")],
-    lastname: Annotated[
-        str,
-        typer.Argument(help="The last name", rich_help_panel="Secondary Arguments"),
-    ] = "",
     age: Annotated[
         int | None,
         typer.Option(help="User age", rich_help_panel="Additional Data"),
@@ -131,7 +139,7 @@ def create(
     print(f"Creating user: {username}")
 ```
 
-Use `rich_help_panel` to organize `--help` output into sections. Use `rich_markup_mode="rich"` on the app for Rich markup in docstrings, or `rich_markup_mode="markdown"` for Markdown.
+Use `rich_help_panel` to organize `--help` output into sections.
 
 ### Testing with CliRunner
 
@@ -156,7 +164,7 @@ def test_app():
 - **Exit codes:** Raise `typer.Exit(code=1)` for non-zero exits. Unhandled exceptions produce code 1 with traceback.
 - **`add_typer()` name parameter is required.** Without it, Typer infers from the module name, which is fragile.
 - **Rich markup in help strings.** Typer renders help strings with Rich, so literal square brackets in help text will be interpreted as markup. Use `\[` to escape.
-- **Option with `prompt=True` and `confirmation_prompt=True`** can be used for sensitive inputs like emails that need double-entry verification.
+- **`envvar=` on `typer.Option`** reads the env var automatically and uses it as a fallback when the CLI flag is not provided. This powers the 5-level precedence chain in DESIGN.md (levels 1-2).
 
 ## Idiomatic Usage
 
@@ -174,6 +182,6 @@ def compliance():
 
 **Don't:** Use `typer.Argument()` as a default value -- the `Annotated` form is the modern convention.
 
-**Do:** Use `rich_help_panel` to organize `--help` output into sections for commands with many options.
+**Do:** Use shared annotated types (`AgentOption`, `ModelOption`, `ProviderOption`) for per-command options that repeat across session commands.
 
 **Do:** Use `typer.Context` parameter for accessing the invoked subcommand or parent context when needed.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -100,7 +100,7 @@ Verification checks file existence (for creates/removes), git diff analysis (for
 
 ### CLI Commands
 
-All commands that launch an assistant session (`spec`, `design`, `patterns`, `execute`, `compliance`) accept a per-command `--agent` / `-a` option and the `PROTHON_AGENT` environment variable. See the Agent Configuration Contract below for the full resolution chain.
+All commands that launch an assistant session (`spec`, `design`, `patterns`, `execute`, `compliance`) accept a per-command `--agent` / `-a` option and the `PROTHON_AGENT` environment variable. When the resolved agent is `opencode`, `--model` / `-m` and `--provider` / `-p` options control which model is used. See the Agent Configuration Contract and Model Configuration Contract below for the full resolution chains.
 
 | Command | Input | Output | Subsystem |
 |---------|-------|--------|-----------|
@@ -156,7 +156,7 @@ Every assistant backend must satisfy the `AssistantBackend` protocol (structural
 - `name` — human-readable name for error messages (e.g. "Claude Code", "opencode")
 - `cli_command` — binary name to look up on PATH (e.g. "claude", "opencode")
 - `install_hint` — installation URL or command for actionable error messages when the binary is missing
-- `build_command(skill_name, cwd)` — constructs the subprocess argv for launching a session. Category A backends reference the skill by name (e.g. `["claude", "--dangerously-skip-permissions", "/prothon-spec-writer"]`). Category B backends read skill content and inject it into the prompt argument.
+- `build_command(skill_name, cwd, model=None)` — constructs the subprocess argv for launching a session. The optional `model` parameter is the resolved `provider/model` string (see Model Configuration Contract). Category A backends reference the skill by name (e.g. `["claude", "--dangerously-skip-permissions", "/prothon-spec-writer"]`). When `model` is provided, backends that support it append `["--model", model]` to the argv. Category B backends read skill content and inject it into the prompt argument.
 - `sync_skills()` — installs/symlinks bundled skills to the assistant's discovery location. Category A backends call `skills.sync_skills(target=...)` with their specific directory. Category B backends may be a no-op.
 - `env_overrides()` — returns a dict of extra environment variables needed for non-interactive execution (e.g. `{"GOOSE_MODE": "auto"}`). Returns an empty dict if none are needed.
 
@@ -195,12 +195,50 @@ Config file format examples:
 # pyproject.toml
 [tool.prothon]
 agent = "opencode"
+model = "glm-5"
+provider = "z-ai"
 ```
 
 ```toml
 # ~/.config/prothon/config.toml
 agent = "opencode"
+model = "glm-5"
+provider = "z-ai"
 ```
+
+### Model Configuration Contract
+
+When the resolved agent is `opencode`, the user can configure which model and provider opencode uses. opencode requires the `provider/model` format on its `--model` flag (e.g. `--model z-ai/glm-5`). Prothon exposes this as two independent configuration values that are resolved separately and joined at invocation time.
+
+**Model precedence** (first non-empty value wins):
+
+| Priority | Source | Mechanism | Example |
+|----------|--------|-----------|---------|
+| 1 (highest) | CLI flag | `--model` / `-m` per-command option | `prothon spec --model glm-5` |
+| 2 | Environment variable | `PROTHON_MODEL` | `export PROTHON_MODEL=glm-5` |
+| 3 | Project config | `[tool.prothon]` in `pyproject.toml` | `model = "glm-5"` |
+| 4 | Global config | `~/.config/prothon/config.toml` (respects `$XDG_CONFIG_HOME`) | `model = "glm-5"` |
+| 5 (lowest) | Default | None | Defer to opencode's own defaults |
+
+**Provider precedence** (identical chain):
+
+| Priority | Source | Mechanism | Example |
+|----------|--------|-----------|---------|
+| 1 (highest) | CLI flag | `--provider` / `-p` per-command option | `prothon spec --provider z-ai-coding` |
+| 2 | Environment variable | `PROTHON_PROVIDER` | `export PROTHON_PROVIDER=z-ai-coding` |
+| 3 | Project config | `[tool.prothon]` in `pyproject.toml` | `provider = "z-ai-coding"` |
+| 4 | Global config | `~/.config/prothon/config.toml` (respects `$XDG_CONFIG_HOME`) | `provider = "z-ai-coding"` |
+| 5 (lowest) | Default | None | Defer to opencode's own defaults |
+
+**Resolution rules:**
+
+- Both `--model` and `--provider` options are per-command, defined on each session command (`spec`, `design`, `patterns`, `execute`, `compliance`) alongside `--agent`, via shared `ModelOption` and `ProviderOption` annotated types.
+- If both model and provider resolve to values, prothon joins them as `provider/model` and passes `--model provider/model` to opencode's `build_command`.
+- If `--model` already contains a `/` (e.g. `--model z-ai/glm-5`), it is treated as a complete `provider/model` specifier and `--provider` is ignored.
+- If only one of model or provider resolves to a value (and the model value does not contain `/`), prothon exits with an error: `--provider requires --model (and vice versa). Use provider/model format or set both.`
+- If neither resolves to a value, opencode is invoked without `--model`, deferring to opencode's own configuration and defaults.
+- When the resolved agent is `claude-code`, both options are silently ignored — Claude Code does not support model selection via prothon.
+- Resolution is implemented as a `resolve_model(cli_model, cli_provider)` function in `cli.py`, following the same pattern as `resolve_agent()`. Environment variables are handled via Typer's `envvar=` parameter on each option definition.
 
 ### Compliance Report Contract
 
@@ -253,3 +291,4 @@ Project-specific reference skills generated by the tech-researcher live in each 
 | Agent selection | 5-level precedence: CLI flag > env var > pyproject.toml > global config > default | Per-command flag; env var only; config file only | Matches universal Python ecosystem convention (uv, ruff, pip, pytest). Typer handles levels 1-2 natively. No new dependencies — tomlkit reads both config sources. |
 | Backend registry | Internal dict with `register_backend()` hook | Entry points (`importlib.metadata`); plugin framework (stevedore, pluggy) | Zero third-party consumers exist. Internal dict is zero-overhead, grep-discoverable, and type-safe. Entry point discovery adds import-time cost and failure modes. Migration to entry points later is a 10-line change. |
 | Backend protocol scope | 6 members: name, cli_command, install_hint, build_command, sync_skills, env_overrides | Minimal 4 members (current); maximal with interactive/non-interactive mode flag | install_hint enables actionable error messages. env_overrides cleanly separates env var concerns from command construction. Interactive/non-interactive mode flag deferred until execute workflow needs it. |
+| Model configuration | Separate `--model` and `--provider` flags joined into opencode's `provider/model` format | Single `--model` accepting `provider/model` only | Separate flags allow setting a project default model and switching providers on the CLI (e.g. `z-ai` vs `z-ai-coding` for the same model). Combined format still accepted in `--model` for convenience. opencode strictly requires `provider/model` — bare model names are rejected. |

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -102,7 +102,7 @@ class OpenCodeBackend: ...              # Category A backend (XDG-aware)
 
 def register_backend(name: str, cls: type) -> None: ...
 def get_backend(name: str = "claude-code") -> AssistantBackend: ...
-def launch(backend: AssistantBackend, skill_name: str, cwd: Path) -> int: ...
+def launch(backend: AssistantBackend, skill_name: str, cwd: Path, model: str | None = None) -> int: ...
 ```
 
 ## Design Patterns
@@ -176,7 +176,7 @@ class AssistantBackend(Protocol):
     @property
     def install_hint(self) -> str: ...
 
-    def build_command(self, skill_name: str, cwd: Path) -> list[str]: ...
+    def build_command(self, skill_name: str, cwd: Path, model: str | None = None) -> list[str]: ...
 
     def sync_skills(self) -> None: ...
 
@@ -196,7 +196,8 @@ class ClaudeCodeBackend:
     def install_hint(self) -> str:
         return "https://docs.anthropic.com/en/docs/claude-code"
 
-    def build_command(self, skill_name: str, cwd: Path) -> list[str]:
+    def build_command(self, skill_name: str, cwd: Path, model: str | None = None) -> list[str]:
+        # model is silently ignored — Claude Code does not support model selection via prothon
         return [self.cli_command, "--dangerously-skip-permissions", f"/{skill_name}"]
 
     def sync_skills(self) -> None:
@@ -220,8 +221,11 @@ class OpenCodeBackend:
     def install_hint(self) -> str:
         return "https://opencode.ai"
 
-    def build_command(self, skill_name: str, cwd: Path) -> list[str]:
-        return [self.cli_command, f"/{skill_name}"]
+    def build_command(self, skill_name: str, cwd: Path, model: str | None = None) -> list[str]:
+        cmd = [self.cli_command, f"/{skill_name}"]
+        if model is not None:
+            cmd.extend(["--model", model])
+        return cmd
 
     def sync_skills(self) -> None:
         from prothon.skills import sync_skills
@@ -275,7 +279,7 @@ def get_backend(name: str = "claude-code") -> AssistantBackend:
 The shared launch lifecycle is a plain function that accepts anything satisfying `AssistantBackend`. This follows the "functions first" default — shared behavior doesn't require a base class.
 
 ```python
-def launch(backend: AssistantBackend, skill_name: str, cwd: Path) -> int:
+def launch(backend: AssistantBackend, skill_name: str, cwd: Path, model: str | None = None) -> int:
     """Shared assistant launch lifecycle."""
     if not shutil.which(backend.cli_command):
         raise AssistantNotFoundError(
@@ -288,7 +292,7 @@ def launch(backend: AssistantBackend, skill_name: str, cwd: Path) -> int:
         raise ProthonError(f"failed to sync skills for {backend.name}: {exc}") from exc
     env = {**os.environ, **backend.env_overrides()}
     return subprocess.run(
-        backend.build_command(skill_name, cwd), cwd=cwd, env=env,
+        backend.build_command(skill_name, cwd, model=model), cwd=cwd, env=env,
     ).returncode
 ```
 
@@ -380,9 +384,9 @@ Status styling uses a dict mapping enum values to `(label, style)` tuples — av
 
 ```python
 _status_styles = {
-    CheckStatus.PASSED: ("PASS", "green"),
-    CheckStatus.FAILED: ("FAIL", "red"),
-    CheckStatus.SKIPPED: ("SKIP", "yellow"),
+    CheckStatus.PASS: ("PASS", "green"),
+    CheckStatus.FAIL: ("FAIL", "red"),
+    CheckStatus.SKIP: ("SKIP", "yellow"),
 }
 for c in report.checks:
     label, style = _status_styles[c.status]
@@ -402,14 +406,42 @@ AgentOption = Annotated[
         help="AI agent backend (claude-code, opencode)",
     ),
 ]
-
-@app.command()
-def spec(agent: AgentOption = None) -> None:
-    root = _require_project_root()
-    _launch_skill("prothon-spec-writer", root, agent)
 ```
 
-This allows natural usage like `prothon patterns --agent opencode`. Typer's `envvar=` parameter handles env var resolution on each command automatically.
+### Per-Command Model/Provider Options with Annotated Types
+
+The `--model`/`-m` and `--provider`/`-p` flags follow the same pattern — shared `Annotated` types added to each session command. These are opencode-specific (Claude Code silently ignores them).
+
+```python
+ModelOption = Annotated[
+    str | None,
+    typer.Option(
+        "--model", "-m",
+        envvar="PROTHON_MODEL",
+        help="Model name (opencode only)",
+    ),
+]
+
+ProviderOption = Annotated[
+    str | None,
+    typer.Option(
+        "--provider", "-p",
+        envvar="PROTHON_PROVIDER",
+        help="Provider name (opencode only)",
+    ),
+]
+
+@app.command()
+def spec(
+    agent: AgentOption = None,
+    model: ModelOption = None,
+    provider: ProviderOption = None,
+) -> None:
+    root = _require_project_root()
+    _launch_skill("prothon-spec-writer", root, agent, model=model, provider=provider)
+```
+
+This allows natural usage like `prothon spec --agent opencode --model glm-5 --provider z-ai`. Typer's `envvar=` parameter handles env var resolution on each command automatically.
 
 ### Fallthrough Precedence Chain
 
@@ -463,6 +495,58 @@ def resolve_agent(cli_value: str | None = None) -> str:
 
 Level 3 wraps `find_project_root()` in a `try/except ProthonError` because it's valid to run prothon outside a project (the resolution just falls through to level 4).
 
+### Model/Provider Resolution and Join Rule
+
+`resolve_model(cli_model, cli_provider)` implements two 5-level precedence chains (one for model, one for provider), then joins them into opencode's required `provider/model` format:
+
+```python
+def _resolve_model_value(cli_value: str | None) -> str | None:
+    if cli_value:
+        return cli_value
+    try:
+        root = find_project_root()
+        val = _nested_get(_read_toml(root / "pyproject.toml"), "tool", "prothon", "model")
+        if val:
+            return val
+    except ProthonError:
+        pass
+    raw_xdg = os.environ.get("XDG_CONFIG_HOME")
+    xdg = Path(raw_xdg) if raw_xdg and Path(raw_xdg).is_absolute() else Path.home() / ".config"
+    val = _nested_get(_read_toml(xdg / "prothon" / "config.toml"), "model")
+    if val:
+        return val
+    return None  # defer to opencode defaults
+
+
+def _resolve_provider_value(cli_value: str | None) -> str | None:
+    # Same structure as _resolve_model_value, but for "provider" key
+    ...
+
+
+def resolve_model(cli_model: str | None, cli_provider: str | None) -> str | None:
+    model = _resolve_model_value(cli_model)
+    provider = _resolve_provider_value(cli_provider)
+
+    if model is None and provider is None:
+        return None  # defer to opencode defaults
+
+    if model is not None and "/" in model:
+        return model  # already in provider/model format, ignore provider flag
+
+    if model is not None and provider is not None:
+        return f"{provider}/{model}"
+
+    raise ProthonError(
+        "--provider requires --model (and vice versa). "
+        "Use provider/model format or set both."
+    )
+```
+
+Resolution rules:
+- If `--model` already contains `/`, treat it as complete `provider/model` and ignore `--provider`
+- If only one of model/provider resolves to a value (and model has no `/`), exit with error
+- If neither resolves, return `None` so opencode uses its own defaults
+
 ### CLI Guard and Launch Helpers
 
 Repeated "find-or-exit" and "resolve-launch-or-exit" logic is extracted into private helpers that catch domain exceptions and raise `typer.Exit`. Keeps command bodies clean.
@@ -482,12 +566,16 @@ def _require_promise_file(root: Path) -> Path:
         raise typer.Exit(1)
     return promise_path
 
-def _launch_skill(skill_name: str, cwd: Path, agent: str | None = None) -> None:
+def _launch_skill(
+    skill_name: str, cwd: Path, agent: str | None = None,
+    model: str | None = None, provider: str | None = None,
+) -> None:
     """Resolve backend, launch skill, handle errors."""
     try:
         name = resolve_agent(agent)
         backend = get_backend(name)
-        rc = launch(backend, skill_name, cwd)
+        resolved_model = resolve_model(model, provider)
+        rc = launch(backend, skill_name, cwd, model=resolved_model)
         if rc != 0:
             raise typer.Exit(rc)
     except ProthonError as exc:
@@ -554,7 +642,9 @@ This is an intentional exception to the standard import order. Use it only for g
 | Rich table helpers | `_render_*` in `cli.py` | Separate rendering from I/O, enum-to-style dicts avoid branching |
 | CLI guard/launch helpers | `_require_project_root()`, `_require_promise_file()`, `_launch_skill()` | Extract repeated find-or-exit and resolve-launch-or-exit into reusable helpers |
 | Per-command option + `Annotated` type | `--agent`/`-a` on each session command via shared `AgentOption` | Explicit data flow, no module-level state, natural CLI usage |
+| Per-command model/provider options | `--model`/`-m`, `--provider`/`-p` on each session command via shared `ModelOption`, `ProviderOption` | Explicit data flow, opencode-specific, silently ignored by Claude Code |
 | Fallthrough precedence | `resolve_agent(cli_value)` 5-level chain | First non-empty value wins; each level is a guard with fallthrough |
+| Model/provider join rule | `resolve_model(cli_model, cli_provider)` | opencode requires `provider/model` format; supports both separate flags and combined format |
 | XDG_CONFIG_HOME resolution | `OpenCodeBackend.sync_skills()`, `resolve_agent()` | Respect user's XDG override with `~/.config` fallback |
 | Prompt validation loops | `prothon new` constrained inputs | Simple while-loop re-prompt, no validation library |
 | Conditional path branching | `init_existing()` Path A/B | Guards first, branch on state, converge on common overlay |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -70,6 +70,7 @@ Prothon is a CLI tool that scaffolds opinionated Python projects and provides a 
 42. The user must be able to select their preferred AI assistant via CLI flag, environment variable, project-level configuration, and global user-level configuration.
 43. Built-in skills must be bundled with the package and synced to the active assistant's skill directory on every CLI invocation.
 44. The scaffolded project's agent instructions must be assistant-agnostic, using symlinks so that any AI assistant that reads project-level markdown picks up the same instructions.
+45. When opencode is the selected assistant, the user must be able to configure a model and provider via the same configuration hierarchy (CLI flag, environment variable, project-level configuration, global user-level configuration). If neither is configured, prothon must invoke opencode without specifying model or provider, deferring to opencode's own defaults.
 
 ## Constraints
 

--- a/docs/refs/init-scaffolding-brief.md
+++ b/docs/refs/init-scaffolding-brief.md
@@ -1,0 +1,33 @@
+# Feature Brief: `prothon init` Python Project Scaffolding
+
+## Problem
+
+`prothon init` only creates documentation and agent files (docs/, AGENTS.md, symlinks, .agents/skills/). When run on a non-Python repo (e.g. a site with just HTML/SVG files), it leaves the user with no `pyproject.toml`, no `src/` layout, no tests, no toolchain — and the suggested next step (`prothon spec`) requires `uv sync` which fails because there's no `pyproject.toml`.
+
+There's no path for: "I have an existing repo, it's not a Python project yet, I want to turn it into one with the prothon workflow."
+
+## Desired Behavior
+
+`prothon init` should detect when `pyproject.toml` is missing and offer to scaffold the full Python project structure alongside the docs workflow. When `pyproject.toml` already exists, it behaves as today (docs-only overlay).
+
+### When `pyproject.toml` is missing:
+
+1. Prompt for project details (same as `prothon new`): module name, description, author name/email, Python version, license
+2. Generate: `pyproject.toml`, `src/{module}/`, `tests/`, `.pre-commit-config.yaml`, CI workflows, `.gitignore`, `README.md`
+3. Must **not overwrite** any existing files — skip files that already exist (e.g. if README.md is already present, keep it)
+4. Create docs + agent files as today
+5. Do **not** run `git init` or create commits (repo already exists)
+
+### When `pyproject.toml` already exists:
+
+No change — docs-only overlay as today.
+
+## Affected SPEC Requirements
+
+- **Requirement 10**: Currently says "adopt an existing Python project" — should broaden to "adopt an existing project" (may or may not be Python yet)
+- **Requirement 17**: Currently says "must not modify existing files, configuration, dependencies, toolchain" — needs nuance: when pyproject.toml is absent, init *creates* the Python structure; it still must not overwrite existing files
+- **New requirement**: When pyproject.toml is missing, init must prompt the user and scaffold the Python project structure using the same template as `prothon new`, skipping any files that already exist
+
+## Design Consideration
+
+The implementation should reuse the existing Copier template infrastructure from `prothon new` rather than duplicating file generation logic. The key difference from `new` is: no git init, no initial commit, and skip-existing-files behavior.


### PR DESCRIPTION
## Summary

- Add `--model`/`-m` and `--provider`/`-p` options for opencode backend
- Implement 5-level precedence chain for model and provider resolution (CLI > env var > pyproject.toml > global config > default)
- Join model/provider into opencode's required `provider/model` format
- Update reference skills to reflect the model parameter in launch lifecycle

## Changes

- **SPEC R45**: New requirement for model/provider configuration when using opencode
- **DESIGN**: Model Configuration Contract with full resolution rules and precedence tables
- **PATTERNS**: `ModelOption`/`ProviderOption` annotated types, `resolve_model()` join rule pattern
- **Reference skills**: Updated domain-ai-agent-orchestration, tech-typer, tech-tomlkit, optim-subprocess-management

## Usage

```bash
# CLI flags
prothon spec --agent opencode --model glm-5 --provider z-ai

# Environment variables
export PROTHON_MODEL=glm-5
export PROTHON_PROVIDER=z-ai

# Project config (pyproject.toml)
[tool.prothon]
agent = "opencode"
model = "glm-5"
provider = "z-ai"

# Global config (~/.config/prothon/config.toml)
agent = "opencode"
model = "glm-5"
provider = "z-ai"
```

If neither model nor provider is configured, opencode is invoked without `--model`, deferring to its own defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model and provider configuration support for opencode assistant via CLI flags (--model/--provider), environment variables, project config, and global config.
  * Introduced explicit configuration precedence hierarchy for agent and model selection.

* **Documentation**
  * Updated design and pattern documentation to reflect model/provider configuration workflow.
  * Enhanced skill documentation with coding conventions and configuration guidance.
  * Added init scaffolding behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->