### PR TITLE
Redesign execute agent for wave-based execution

### DIFF
--- a/src/prothon/cli.py
+++ b/src/prothon/cli.py
@@ -516,18 +516,16 @@ def promise_check(
 @promise_app.command("complete")
 def promise_complete(
     task_index: int = typer.Argument(help="Zero-based task index to mark complete"),
-    attempts: int = typer.Argument(default=1, help="Number of attempts taken"),
 ) -> None:
-    """Mark a task as completed and record attempt count."""
+    """Mark a task as completed (attempt count is read from the promise file)."""
     root = _require_project_root()
     promise_path = _require_promise_file(root)
     try:
-        promise.complete_task(task_index, attempts=attempts, path=promise_path)
+        promise.complete_task(task_index, path=promise_path)
     except ProthonError as exc:
         typer.echo(f"Error: {exc}")
         raise typer.Exit(1)
-    suffix = "s" if attempts != 1 else ""
-    typer.echo(f"Task {task_index} marked as completed ({attempts} attempt{suffix}).")
+    typer.echo(f"Task {task_index} marked as completed.")
 
 
 @promise_app.command("record-attempt")

--- a/src/prothon/promise.py
+++ b/src/prothon/promise.py
@@ -149,6 +149,16 @@ class Promise:
     tasks: list[Task] = field(default_factory=list)
 
 
+def _coerce_int(value: object, field: str) -> int:
+    """Coerce a TOML value to int, raising PromiseError on failure."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise PromiseError(
+            f"field '{field}' must be an integer, got {type(value).__name__}: {value!r}"
+        )
+
+
 def _task_from_dict(d: dict) -> Task:
     """Construct a Task from a TOML dict, tolerating missing keys."""
     return Task(
@@ -159,15 +169,19 @@ def _task_from_dict(d: dict) -> Task:
         files_to_create=list(d.get("files_to_create", [])),
         files_to_modify=list(d.get("files_to_modify", [])),
         files_to_remove=list(d.get("files_to_remove", [])),
-        expected_lines_added=d.get("expected_lines_added", 0),
-        expected_lines_removed=d.get("expected_lines_removed", 0),
+        expected_lines_added=_coerce_int(
+            d.get("expected_lines_added", 0), "expected_lines_added"
+        ),
+        expected_lines_removed=_coerce_int(
+            d.get("expected_lines_removed", 0), "expected_lines_removed"
+        ),
         context_files=list(d.get("context_files", [])),
         doc_sections=list(d.get("doc_sections", [])),
         reference_skills=list(d.get("reference_skills", [])),
         dependencies=list(d.get("dependencies", [])),
         completed=d.get("completed", False),
-        max_attempts=d.get("max_attempts", 3),
-        attempts=d.get("attempts", 0),
+        max_attempts=_coerce_int(d.get("max_attempts", 3), "max_attempts"),
+        attempts=_coerce_int(d.get("attempts", 0), "attempts"),
     )
 
 
@@ -428,7 +442,6 @@ def check_task(
 def complete_task(
     task_index: int,
     *,
-    attempts: int = 1,
     diff: GitDiffProvider | None = None,
     path: Path = PROMISE_PATH,
 ) -> None:
@@ -437,9 +450,11 @@ def complete_task(
     Runs ``check_task`` first and refuses to mark the task complete if
     any check fails (SPEC R34: compliance mandatory before completion).
 
+    The persisted ``attempts`` counter (incremented by ``record_attempt``)
+    is preserved as-is — this function does not overwrite it.
+
     Args:
         task_index: Zero-based index of the task to mark complete.
-        attempts: Number of attempts taken to complete the task.
         diff: Git diff data source; defaults to SubprocessGitDiff().
         path: Path to the promise TOML file.
 
@@ -451,7 +466,6 @@ def complete_task(
         raise PromiseError(
             f"Task {task_index} cannot be completed: promise checks failed"
         )
-    # Lock the promise file so parallel completions don't overwrite each other.
     with _lock_promise(path):
         promise = load_promise(path)
         if task_index < 0 or task_index >= len(promise.tasks):
@@ -468,8 +482,43 @@ def complete_task(
         if promise.tasks[task_index].completed:
             return
         promise.tasks[task_index].completed = True
-        promise.tasks[task_index].attempts = attempts
-        save_promise(promise, path)
+        _update_task_fields(path, task_index, {"completed": True})
+
+
+def _update_task_fields(path: Path, task_index: int, updates: dict) -> None:
+    """Mutate specific task fields in the TOML file, preserving comments and formatting.
+
+    Must be called while ``_lock_promise`` is held.
+    """
+    try:
+        doc = tomlkit.parse(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise PromiseError(f"promise file not found: {path}") from None
+    tasks = doc.get("tasks", [])
+    if task_index < 0 or task_index >= len(tasks):
+        raise PromiseError(
+            f"Task index {task_index} out of range; promise file may have changed"
+        )
+    for key, value in updates.items():
+        tasks[task_index][key] = value
+    content = tomlkit.dumps(doc)
+    data = content.encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        written = 0
+        while written < len(data):
+            written += os.write(fd, data[written:])
+        os.fsync(fd)
+    except BaseException:
+        os.close(fd)
+        os.unlink(tmp)
+        raise
+    os.close(fd)
+    try:
+        os.replace(tmp, path)
+    except BaseException:
+        os.unlink(tmp)
+        raise
 
 
 def record_attempt(
@@ -484,7 +533,7 @@ def record_attempt(
         path: Path to the promise TOML file.
 
     Raises:
-        PromiseError: If task_index is out of range.
+        PromiseError: If task_index is out of range or attempts is not an integer.
     """
     with _lock_promise(path):
         promise = load_promise(path)
@@ -492,8 +541,8 @@ def record_attempt(
             raise PromiseError(
                 f"Task index {task_index} out of range; promise file may have changed"
             )
-        promise.tasks[task_index].attempts += 1
-        save_promise(promise, path)
+        new_attempts = promise.tasks[task_index].attempts + 1
+        _update_task_fields(path, task_index, {"attempts": new_attempts})
 
 
 def status(path: Path = PROMISE_PATH) -> str:

--- a/src/prothon/skills/prothon-execute/SKILL.md
+++ b/src/prothon/skills/prothon-execute/SKILL.md
@@ -58,11 +58,11 @@ attempts = 0
 For each task in the promise (respecting dependency order):
 
 1. **Orchestrate Retries** — While `attempts < max_attempts` and task is not `completed`:
-   a) **Launch Subagent** — Spawn a **fresh** Claude/OpenCode instance (type: general-purpose) with the "Task Implementation Prompt" below.
-   b) **Monitor Result**:
+   a) **Record attempt** — Run: `uvx prothon promise record-attempt {task_index}` (counts every attempt, including the one about to start).
+   b) **Launch Subagent** — Spawn a **fresh** Claude/OpenCode instance (type: general-purpose) with the "Task Implementation Prompt" below.
+   c) **Monitor Result**:
       - If subagent reports **SUCCESS** (task marked complete): Proceed to next task.
       - If subagent reports **FAILURE**:
-        - Run: `uvx prothon promise record-attempt {task_index}`
         - If `attempts >= max_attempts`, report failure to user and ask skip/retry/abort.
         - Otherwise, loop back to step (a) to spawn a **fresh** instance with the same goal + failure context.
 
@@ -70,7 +70,7 @@ For each task in the promise (respecting dependency order):
 
 ### Task Implementation Prompt
 
-```
+```text
 You are implementing a single task with fresh context. You MUST close the session on completion.
 
 1. READ CONTEXT:
@@ -92,7 +92,7 @@ You are implementing a single task with fresh context. You MUST close the sessio
 
 4. EXIT:
    - If `promise check` passed:
-     - Run: `uvx prothon promise complete {task_index} {attempts}`
+     - Run: `uvx prothon promise complete {task_index}`
      - Report SUCCESS and close session.
    - If any step failed:
      - Report FAILURE with context on what went wrong and close session.

--- a/tests/test_promise.py
+++ b/tests/test_promise.py
@@ -29,6 +29,7 @@ from prothon.promise import (
     complete_task,
     load_promise,
     plan,
+    record_attempt,
     save_promise,
     status,
 )
@@ -312,25 +313,10 @@ def test_complete_task_index_out_of_range(promise_file: Path):
         complete_task(99, diff=FakeGitDiff(), path=promise_file)
 
 
-def test_complete_task_records_attempts(tmp_path: Path):
+def test_complete_task_preserves_persisted_attempts(tmp_path: Path):
     promise = Promise(
         metadata=Metadata(base_commit="abc1234"),
-        tasks=[Task(title="Test")],
-    )
-    p = tmp_path / "promise.toml"
-    save_promise(promise, p)
-
-    complete_task(0, attempts=3, diff=FakeGitDiff(), path=p)
-
-    result = load_promise(p)
-    assert result.tasks[0].completed is True
-    assert result.tasks[0].attempts == 3
-
-
-def test_complete_task_defaults_to_one_attempt(tmp_path: Path):
-    promise = Promise(
-        metadata=Metadata(base_commit="abc1234"),
-        tasks=[Task(title="Test")],
+        tasks=[Task(title="Test", attempts=3)],
     )
     p = tmp_path / "promise.toml"
     save_promise(promise, p)
@@ -338,7 +324,45 @@ def test_complete_task_defaults_to_one_attempt(tmp_path: Path):
     complete_task(0, diff=FakeGitDiff(), path=p)
 
     result = load_promise(p)
-    assert result.tasks[0].attempts == 1
+    assert result.tasks[0].completed is True
+    assert result.tasks[0].attempts == 3
+
+
+def test_task_from_dict_coerces_string_attempts():
+    """Malformed attempts (e.g. quoted string) should raise PromiseError."""
+    with pytest.raises(PromiseError, match="must be an integer"):
+        _task_from_dict({"title": "Bad", "attempts": "zero"})
+
+
+def test_record_attempt_preserves_comments(tmp_path: Path):
+    """record_attempt must not destroy TOML comments (DESIGN.md requirement)."""
+    p = tmp_path / "promise.toml"
+    p.write_text(
+        '[metadata]\nbase_commit = "abc"\n\n'
+        "# This is a task comment\n"
+        "[[tasks]]\n"
+        'title = "Test"\n'
+        'task_id = "deadbeef"\n'
+        'goal = ""\n'
+        'success_criteria = ""\n'
+        "files_to_create = []\n"
+        "files_to_modify = []\n"
+        "files_to_remove = []\n"
+        "expected_lines_added = 0\n"
+        "expected_lines_removed = 0\n"
+        "context_files = []\n"
+        "doc_sections = []\n"
+        "reference_skills = []\n"
+        "dependencies = []\n"
+        "completed = false\n"
+        "attempts = 0\n"
+        "max_attempts = 3\n",
+        encoding="utf-8",
+    )
+    record_attempt(0, path=p)
+    content = p.read_text(encoding="utf-8")
+    assert "# This is a task comment" in content
+    assert "attempts = 1" in content
 
 
 def test_record_attempt_increments_counter(tmp_path: Path):
@@ -348,8 +372,6 @@ def test_record_attempt_increments_counter(tmp_path: Path):
     )
     p = tmp_path / "promise.toml"
     save_promise(promise, p)
-
-    from prothon.promise import record_attempt
 
     record_attempt(0, path=p)
 
@@ -369,10 +391,29 @@ def test_record_attempt_index_out_of_range(tmp_path: Path):
     p = tmp_path / "promise.toml"
     save_promise(promise, p)
 
-    from prothon.promise import record_attempt
-
     with pytest.raises(PromiseError, match="out of range"):
         record_attempt(99, path=p)
+
+
+def test_record_attempt_parallel_no_lost_updates(tmp_path: Path):
+    """Concurrent record_attempt calls must not lose increments."""
+    import concurrent.futures
+
+    p_obj = Promise(
+        metadata=Metadata(base_commit="abc1234"),
+        tasks=[Task(title="Concurrent", attempts=0)],
+    )
+    path = tmp_path / "promise.toml"
+    save_promise(p_obj, path)
+
+    n_threads = 5
+    with concurrent.futures.ThreadPoolExecutor(max_workers=n_threads) as pool:
+        futures = [pool.submit(record_attempt, 0, path=path) for _ in range(n_threads)]
+        for f in futures:
+            f.result()
+
+    result = load_promise(path)
+    assert result.tasks[0].attempts == n_threads
 
 
 def test_complete_task_refuses_when_checks_fail(tmp_path: Path):


### PR DESCRIPTION
Redesigned the execute agent to work in phases with Ralph-style loops that spawn a fresh Claude/OpenCode instance per task. This solves context pollution and incomplete work by:
- Implementing phase-based execution where each invocation determines the next logical wave of work dynamically.
- Introducing 'record-attempt' infrastructure to track failed attempts across fresh-context subagent instances.
- Updating the prothon-execute skill to orchestrate retries and enforce strict per-task quality gates.
- Ensuring the agent remains stateless between invocations, converging toward full implementation by narrowing the gap between docs and code.

Fixes #22

---
*PR created automatically by Jules for task [8531223011869325365](https://jules.google.com/task/8531223011869325365) started by @jackedney*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to record/increment a task's attempt counter.
  * Completion now reads the persisted attempt count from the promise file (not supplied as an argument).

* **Behavior Changes**
  * Task completion preserves the persisted attempts counter.
  * Per-task execution now uses phase-scoped planning and fresh-context retry loops with explicit retry tracking.

* **Documentation**
  * Execution skill guide rewritten to Phase-based Plan/Execute/Verify flow and simplified task spec.

* **Tests**
  * Added tests for attempt recording, concurrent increments, and preserving attempts on completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->